### PR TITLE
Make product images visible

### DIFF
--- a/connectors-shopify/server/methods/api/api.js
+++ b/connectors-shopify/server/methods/api/api.js
@@ -28,6 +28,8 @@ export function getApiInfo(shopId = Reaction.getShopId()) {
   return {
     apiKey: settings.apiKey,
     password: settings.password,
-    shopName: settings.shopName
+    shopName: settings.shopName,
+    timeout: 300000, // Defaults to 60000, or 1 minute.
+    autoLimit: true
   };
 }

--- a/connectors-shopify/server/methods/import/products.js
+++ b/connectors-shopify/server/methods/import/products.js
@@ -85,6 +85,8 @@ function createReactionProductFromShopifyProduct(options) {
  */
 function createReactionVariantFromShopifyVariant(options) {
   const { shopifyVariant, variant, index, ancestors, shopId } = options;
+  const inventoryInStock = shopifyVariant.inventory_quantity >= 0 ? shopifyVariant.inventory_quantity : 0;
+
   const reactionVariant = {
     ancestors,
     barcode: shopifyVariant.barcode,
@@ -94,7 +96,8 @@ function createReactionVariantFromShopifyVariant(options) {
     index,
     inventoryManagement: true,
     inventoryPolicy: shopifyVariant.inventory_policy === "deny",
-    inventoryQuantity: shopifyVariant.inventory_quantity >= 0 ? shopifyVariant.inventory_quantity : 0,
+    inventoryInStock,
+    inventoryAvailableToSell: inventoryInStock,
     isDeleted: false,
     isVisible: true,
     length: 0,
@@ -338,7 +341,7 @@ export const methods = {
                   ownerId: Meteor.userId(),
                   productId: reactionProductId,
                   shopId,
-                  priority: productImage.position, // Shopify index positions starting at 1.
+                  priority: productImage.position-1, // Shopify index positions starting at 1.
                   toGrid: 1
                 });
               }

--- a/connectors-shopify/server/methods/import/products.js
+++ b/connectors-shopify/server/methods/import/products.js
@@ -321,7 +321,8 @@ export const methods = {
             ids.push(reactionProductId);
 
             // Save the primary image to the grid and as priority 0
-            saveImage(shopifyProduct.image.src, {
+            const primaryImage = {src: null, ...shopifyProduct.image}
+            saveImage(primaryImage.src, {
               ownerId: Meteor.userId(),
               productId: reactionProductId,
               shopId,

--- a/connectors-shopify/server/methods/import/products.js
+++ b/connectors-shopify/server/methods/import/products.js
@@ -324,7 +324,6 @@ export const methods = {
             saveImage(shopifyProduct.image.src, {
               ownerId: Meteor.userId(),
               productId: reactionProductId,
-              variantId: reactionProductId,
               shopId,
               priority: 0,
               toGrid: 1
@@ -337,10 +336,9 @@ export const methods = {
                 saveImage(productImage.src, {
                   ownerId: Meteor.userId(),
                   productId: reactionProductId,
-                  variantId: reactionProductId,
                   shopId,
                   priority: productImage.position, // Shopify index positions starting at 1.
-                  toGrid: 0
+                  toGrid: 1
                 });
               }
             }


### PR DESCRIPTION
Currently, the Product images are hidden as they have `variantId` and `toGrid=0`.

On new image upload, we do not have `variantId` and `toGrid=1` for Media.filerecord table in DB, which makes the images visible on Storefront as well as in the media section of reaction admin Products page. 

Applying the same rules for the imported images to make them visible in Storefront and Admin Products page. 